### PR TITLE
fix __dir__ set union operator

### DIFF
--- a/odooly.py
+++ b/odooly.py
@@ -1415,7 +1415,7 @@ class BaseRecord(BaseModel):
                                  self._name, ids)
 
     def __dir__(self):
-        attrs = set(self.__dict__) + set(self._model._keys)
+        attrs = set(self.__dict__) | set(self._model._keys)
         return sorted(attrs)
 
     def __bool__(self):


### PR DESCRIPTION
When trying to use dir() over I model I got:

```
TypeError: unsupported operand type(s) for +: 'dict' and 'dict'
```

The fix is to use the `|` instead.