### PR TITLE
[FIX] odooly: compatibility with odoo saas versions

### DIFF
--- a/odooly.py
+++ b/odooly.py
@@ -942,7 +942,7 @@ class Client(object):
 
         float_version = 99.0
         self.server_version = ver = get_service('db').server_version()
-        self.major_version = re.match(r'\d+\.?\d*', ver).group()
+        self.major_version = re.search(r'\d+\.?\d*', ver).group()
         self.version_info = float_version = float(self.major_version)
         assert float_version > 6.0, 'Not supported: %s' % ver
         # Create the RPC services


### PR DESCRIPTION
Issue with odoo saas versions. 
Ex: 'saas~18.3+e'
Last stable Odoo version 18.at this moment

Before this pr:  'NoneType' object has no attribute 'group'
The regex doesn't find a coincidence, so return error when doing group()

