### PR TITLE
Support local mode with Odoo >= 15.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 * Support :method:`RecordList.copy`.
   With Odoo >= 18.0
 
+* Extend local mode to support Odoo >= 15.0.
+
 
 2.2.0 (2025-09-16)
 ~~~~~~~~~~~~~~~~~~

--- a/odooly.py
+++ b/odooly.py
@@ -275,7 +275,7 @@ def start_odoo_services(options=None, appname=None):
             odoo.service.web_services.start_web_services()
         elif odoo.release.version_info < (8,):
             odoo.service.start_internal()
-        else:   # Odoo v8
+        elif odoo.release.version_info < (15,):
             odoo.api.Environment.reset()
 
         try:


### PR DESCRIPTION
It restores the possibility to run in local mode ( `import odoo` ) for versions 15.0, 16.0, 17.0, 18.0 and 19.0.
