### PR TITLE
Use the Webclient API by default for Odoo >= 9.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Odooly
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 jobs:
   build:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog
 * Use a Web session for JSON-RPC requests
   when Requests is installed.
 
+* Drop support for Python 3.5
+
 
 2.2.1 (2025-09-24)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,20 @@ Changelog
 2.x.x (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-* Use a Web session for JSON-RPC requests
-  when Requests is installed.
+* Support webclient :class:`WebAPI` protocol as an alternative:
+  ``/web/dataset/*``, ``/web/database/*``, ...
+  Webclient API is stable since Odoo 9.0
+
+* Authenticate with ``/web/session/authenticate`` by default
+  and retrieve :attr:`Env.session_info`, with Odoo >= 9.0.
+
+* Use Webclient API by default when ``protocol`` is not set.
+  It is same as setting ``protocol = web``
+
+* New function :meth:`Client.drop_database`.
+
+* New functions to create/destroy a session:
+  :meth:`Env.session_authenticate` and :meth:`Env.session_destroy`.
 
 * Drop support for Python 3.5
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Key features:
 - simplified syntax for search ``domain`` and ``fields``
 - full API accessible on the ``Client.env`` environment
 - the module can be imported and used as a library: ``from odooly import Client``
-- supports Python 3.5 and above
+- supports Python 3.6 and above
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,13 @@ Download and install the latest release::
    :local:
    :backlinks: top
 
-Documentation and tutorial: http://odooly.readthedocs.org
+Documentation and tutorial: https://odooly.readthedocs.io/
 
 
 Overview
 --------
 
-Odooly carries three completing uses:
+Odooly carries three modes of use:
 
 (1) with command line arguments
 (2) as an interactive shell
@@ -25,14 +25,15 @@ Odooly carries three completing uses:
 
 Key features:
 
-- provides an API very close to the Odoo API, through JSON-RPC and XML-RPC
+- provides an API similar to Odoo Model, through Webclient API
 - compatible with OpenERP 6.1 through Odoo 19.0
-- single executable ``odooly.py``, no external dependency
+- supports external APIs JSON-RPC and XML-RPC as alternative
+- single file ``odooly.py``, no external dependency
 - helpers for ``search``, for data model introspection, etc...
-- simplified syntax for search ``domain`` and ``fields``
-- full API accessible on the ``Client.env`` environment
-- the module can be imported and used as a library: ``from odooly import Client``
-- supports Python 3.6 and above
+- simplified syntax for search ``domain``
+- entire API accessible on the ``Client.env`` environment
+- can be imported and used as a library: ``from odooly import Client``
+- supports Python 3.6 and more recent
 
 
 
@@ -59,7 +60,7 @@ Although it is quite limited::
       -c CONFIG, --config=CONFIG
                             specify alternate config file (default: 'odooly.ini')
       --server=SERVER       full URL of the server (default:
-                            http://localhost:8069/xmlrpc)
+                            http://localhost:8069/web)
       -d DB, --db=DB        database
       -u USER, --user=USER  username
       -p PASSWORD, --password=PASSWORD
@@ -113,7 +114,7 @@ Edit ``odooly.ini`` and declare the environment(s)::
     [demo]
     username = demo
     password = demo
-    protocol = xmlrpc
+    protocol = web
 
     [demo_jsonrpc]
     username = demo
@@ -164,6 +165,6 @@ This is a sample session::
 
 .. note::
 
-   To preserve the history of commands when closing the session, first
+   To preserve the commands' history when closing the session, first
    create an empty file in your home directory:
    ``touch ~/.odooly_history``

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,9 +8,9 @@ The library provides few objects to access the Odoo model and the
 associated services of `the Odoo API`_.
 
 The signature of the methods mimics the standard methods provided by the
-:class:`osv.Model` Odoo class.  This is intended to help the developer when
-developping addons.  What is experimented at the interactive prompt should
-be portable in the application with little effort.
+:class:`odoo.models.Model` Odoo class.  This is intended to help the developer
+when developping addons.  What is experimented at the interactive prompt
+should be portable in the application with little effort.
 
 .. contents::
    :local:
@@ -21,9 +21,10 @@ be portable in the application with little effort.
 Client and Services
 -------------------
 
-The :class:`Client` object provides thin wrappers around Odoo RPC services
-and their methods.  Additional helpers are provided to explore the models and
-list or install Odoo add-ons.
+The :class:`Client` object provides thin wrappers around Odoo Webclient API
+and RPC services and their methods.  Additional helpers are provided on the
+``Client.env`` environment, to explore the models and to list or to install
+Odoo add-ons.  Please refer to :class:`Env` documentation below.
 
 
 .. autoclass:: Client
@@ -34,7 +35,13 @@ list or install Odoo add-ons.
 
 .. automethod:: Client.clone_database
 
+.. automethod:: Client.drop_database
+
 .. automethod:: Client.login
+
+.. attribute:: Client.env
+
+   Current :class:`Env` environment of the client.
 
 
 .. note::
@@ -50,16 +57,53 @@ list or install Odoo add-ons.
    ``ODOOLY_SSL_UNVERIFIED=1``.
 
 
+Odoo Webclient API
+~~~~~~~~~~~~~~~~~~
+
+These HTTP routes were developed for the Odoo Web application.  They are used
+by Odooly to provide high level methods on :class:`Env` and :class:`Model`.
+The :attr:`~Client.database` endpoint exposes few methods which might be helpful
+for database management.  Use :func:`dir` function to introspect them.
+
+.. attribute:: Client.database
+
+   Expose the ``database`` :class:`WebAPI`.
+
+   Example: :meth:`Client.database.list` method.
+
+.. attribute:: Client.web
+
+   Expose the root ``/web`` :class:`WebAPI`.
+
+.. attribute:: Client.web_dataset
+
+   Expose the ``/web/dataset`` :class:`WebAPI`.
+
+.. attribute:: Client.web_session
+
+   Expose the ``/web/session`` :class:`WebAPI`.
+
+.. attribute:: Client.web_webclient
+
+   Expose the ``/web/webclient`` :class:`WebAPI`.
+
+
 Odoo RPC Services
 ~~~~~~~~~~~~~~~~~
 
-The naked Odoo RPC services are exposed too.
-The :attr:`~Client.db` and the :attr:`~Client.common` services expose few
+.. note::
+
+   These RPC services are deprecated in Odoo 19.0.  They are
+   scheduled for removal in Odoo 20.0.
+
+The Odoo RPC services are exposed too. They could be used for server and
+database operations.
+The :attr:`~Client.db` and the :attr:`~Client.common` services provided
 methods which might be helpful for server administration.  Use the
 :func:`dir` function to introspect them.  The :attr:`~Client._object`
-service should not be used directly because its methods are wrapped and
-exposed on the :class:`Env` object itself.
-The two last services are deprecated and removed in recent versions of Odoo.
+service should not be used directly.  It provides same feature as the
+:attr:`~Client.web_dataset` Webclient endpoint.  Use :class:`Env` and :class:`Model`
+instead.
 Please refer to `the Odoo documentation`_ for more details.
 
 
@@ -70,15 +114,21 @@ Please refer to `the Odoo documentation`_ for more details.
    Examples: :meth:`Client.db.list` or :meth:`Client.db.server_version`
    RPC methods.
 
+   Removed in Odoo 20.
+
 .. attribute:: Client.common
 
    Expose the ``common`` :class:`Service`.
 
    Example: :meth:`Client.common.login_message` RPC method.
 
+   Removed in Odoo 20.
+
 .. data:: Client._object
 
    Expose the ``object`` :class:`Service`.
+
+   Removed in Odoo 20.
 
 .. attribute:: Client._report
 
@@ -92,12 +142,16 @@ Please refer to `the Odoo documentation`_ for more details.
 
    Removed in OpenERP 7.
 
+.. autoclass:: WebAPI
+   :members:
+   :undoc-members:
+
 .. autoclass:: Service
    :members:
    :undoc-members:
 
 .. _the Odoo documentation:
-.. _the Odoo API: http://doc.odoo.com/v6.1/developer/12_api.html#api
+.. _the Odoo API: https://www.odoo.com/documentation/19.0/developer/reference/external_rpc_api.html
 
 
 Environment
@@ -131,6 +185,16 @@ Environment
 
       Cursor on the current database.
 
+   .. automethod:: session_authenticate
+
+   .. automethod:: session_destroy
+
+   .. attribute:: session_info
+
+      Dictionary returned when a Webclient session is authenticated.
+      It contains ``uid`` and ``user_context`` among other user's preferences
+      and server parameters.
+
    .. automethod:: sudo(user=SUPERUSER_ID)
 
 
@@ -150,6 +214,12 @@ Please refer to `the Odoo documentation`_ for details.
 
 
 .. automethod:: Env.execute(obj, method, *params, **kwargs)
+
+.. automethod:: Env._call_kw(obj, method, *params, **kwargs)
+
+.. attribute:: Env._web(obj, method, *params, **kwargs)
+
+   Expose the root of the ``/web`` API.
 
 .. method:: Env.exec_workflow(obj, signal, obj_id)
 
@@ -212,7 +282,7 @@ Python script or interactively in a Python session.
    It is not recommended to install or upgrade modules in offline mode when
    any web server is still running: the operation will not be signaled to
    other processes.  This restriction does not apply when connected through
-   XML-RPC or JSON-RPC.
+   Webclient API or other RPC API.
 
 
 .. _model-and-records:
@@ -222,7 +292,7 @@ Model and Records
 
 The :class:`Env` provides a high level API similar to the Odoo API, which
 encapsulates objects into `Active Records
-<http://www.martinfowler.com/eaaCatalog/activeRecord.html>`_.
+<https://www.martinfowler.com/eaaCatalog/activeRecord.html>`_.
 
 The :class:`Model` is instantiated using the ``client.env[...]`` syntax.
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -22,12 +22,13 @@ complex tasks.
 For example:
 
 * write unit tests using the standard `unittest
-  <http://docs.python.org/library/unittest.html>`_ framework.
-* write BDD tests using the `Gherkin language <http://packages.python.org/
-  behave/gherkin.html#gherkin-feature-testing-language>`_, and a library
-  like `Behave <http://packages.python.org/behave/>`_.
+  <https://docs.python.org/library/unittest.html>`_ framework.
+* write BDD tests using the `Gherkin language <https://behave.readthedocs.io/
+  en/latest/gherkin/#gherkin-feature-testing-language>`_, and a library
+  like `Behave <https://behave.readthedocs.io/>`_.
 * build an interface for Odoo, using a framework like
-  `Flask <http://flask.pocoo.org/>`_ (HTML, JSON, SOAP, ...).
+  `Flask <https://flask.palletsprojects.com/>`_ (HTML, JSON, SOAP, ...).
+
 
 
 Changes

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,11 +10,11 @@ Odooly's documentation
 *A versatile tool for browsing Odoo / OpenERP data*
 
 The Odooly library communicates with any `Odoo / OpenERP server`_ (>= 6.1)
-using `the standard XML-RPC interface`_ or the new JSON-RPC interface.
+using the Webclient API or `the deprecated external RPC interface`_ (JSON-RPC or XML-RPC).
 
 It provides both a :ref:`fully featured low-level API <client-and-services>`,
 and an encapsulation of the methods on :ref:`Active Record objects
-<model-and-records>`.  It implements the Odoo API 8.0.
+<model-and-records>`.  It implements the Odoo API.
 Additional helpers are provided to explore the model and administrate the
 server remotely.
 
@@ -35,11 +35,11 @@ Contents:
    tutorial
    developer
 
-* Online documentation: http://odooly.readthedocs.org/
+* Online documentation: https://odooly.readthedocs.io/
 * Source code and issue tracker: https://github.com/tinyerp/odooly
 
-.. _Odoo / OpenERP server: http://doc.odoo.com/
-.. _the standard XML-RPC interface: http://doc.odoo.com/v6.1/developer/12_api.html#api
+.. _Odoo / OpenERP server: https://www.odoo.com/documentation/
+.. _the deprecated external RPC interface: https://www.odoo.com/documentation/19.0/developer/reference/external_rpc_api.html
 
 
 Indices and tables

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -10,7 +10,7 @@ Installation
 ------------
 
 Download and install the `latest release
-<http://pypi.python.org/pypi/Odooly>`__ from PyPI::
+<https://pypi.org/project/Odooly>`__ from PyPI::
 
     pip install -U odooly
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -6,7 +6,7 @@ Tutorial
 
 This tutorial demonstrates some features of Odooly in the interactive shell.
 
-It assumes an Odoo or OpenERP server is installed.
+It assumes an Odoo server is installed.
 The shell is a true Python shell.  We have access to all the features and
 modules of the Python interpreter.
 
@@ -32,11 +32,16 @@ If our configuration is different, then we use arguments, like::
 
     $ odooly --server http://192.168.0.42:8069
 
-It connects using the XML-RPC protocol. If you want to use the JSON-RPC
-protocol instead, then pass the full URL with ``/jsonrpc`` path::
+It connects using the Webclient API. If you want to use the JSON-RPC
+external API instead, then pass the full URL with ``/jsonrpc`` path::
 
     $ odooly --server http://127.0.0.1:8069/jsonrpc
 
+
+.. note::
+
+    These protocols JSON-RPC and XML-RPC are deprecated in Odoo 19.0 and will
+    be removed in Odoo 20.0.
 
 On login, it prints few lines about the commands available.
 
@@ -64,6 +69,7 @@ On login, it prints few lines about the commands available.
         env.install(module1, module2, ...)
         env.upgrade(module1, module2, ...)
                                         # Install or upgrade the modules
+        env.upgrade_cancel()            # Reset failed upgrade/install
 
 And it confirms that the default database is not available::
 
@@ -73,9 +79,9 @@ And it confirms that the default database is not available::
 Though, we have a connected client, ready to use::
 
     >>> client
-    <Client 'http://localhost:8069/xmlrpc#()'>
+    <Client 'http://localhost:8069/web#()'>
     >>> client.server_version
-    '6.1'
+    '18.0'
     >>> #
 
 
@@ -96,8 +102,8 @@ Default password is ``"admin"``.
     >>> client.create_database('super_password', 'demo')
     Logged in as 'admin'
     >>> client
-    <Client 'http://localhost:8069/xmlrpc#demo'>
-    >>> client.db.list()
+    <Client 'http://localhost:8069/web#demo'>
+    >>> client.database.list()
     ['demo']
     >>> env
     <Env 'admin@demo'>
@@ -137,8 +143,8 @@ database name and the superadmin password.
     >>> client.clone_database('super_password', 'demo_test')
     Logged in as 'admin'
     >>> client
-    <Client 'http://localhost:8069/xmlrpc#demo_test'>
-    >>> client.db.list()
+    <Client 'http://localhost:8069/web#demo_test'>
+    >>> client.database.list()
     ['demo', 'demo_test']
     >>> env
     <Env 'admin@demo'>
@@ -160,7 +166,7 @@ Where is the table for the users?
 .. sourcecode:: pycon
 
     >>> client
-    <Client 'http://localhost:8069/xmlrpc#demo'>
+    <Client 'http://localhost:8069/web#demo'>
     >>> env.models('user')
     ['res.users', 'res.users.log']
 

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -21,7 +21,7 @@ class TestInteract(XmlRpcTestCase):
     )
 
     def setUp(self):
-        super(TestInteract, self).setUp()
+        super().setUp()
         # Hide readline module
         mock.patch.dict('sys.modules', {'readline': None}).start()
         mock.patch('odooly.Client._globals', None).start()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -86,7 +86,7 @@ class TestCase(XmlRpcTestCase):
         return [sentinel.OTHER]
 
     def setUp(self):
-        super(TestCase, self).setUp()
+        super().setUp()
         self.service.object.execute_kw.side_effect = self.obj_exec
         # preload 'foo.bar'
         self.env['foo.bar']


### PR DESCRIPTION
Next internal change, to use the Webclient API, since RPC services are deprecated in Odoo 19.0 and removed in Odoo 20.0.

- OCA/odoorpc#101