### PR TITLE
Fix context_get arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.x.x (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
+* Fix `context_get` arguments.
+
 * Fix PyPI classifiers.
 
 * Update documentation.

--- a/odooly.py
+++ b/odooly.py
@@ -611,7 +611,8 @@ class Env:
         self.session_info = info
         user_context = info.get('user_context') or {}
         if not user_context and self.client._object:
-            user_context = self.client._object.execute_kw(self.db_name, uid, password, 'res.users', 'context_get')
+            args = self.db_name, uid, password, 'res.users', 'context_get', ()
+            user_context = self.client._object.execute_kw(*args)
         if context:
             user_context = {**user_context, **context}
         return (uid, password, user_context)

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -21,7 +21,7 @@ def OBJ(model, method, *params, **kw):
         kw['context'] = sample_context
     elif kw['context'] is None:
         del kw['context']
-    extra = (params, kw) if kw else (params,) if params else ()
+    extra = (params, kw) if kw else (params,)
     return ('object.execute_kw', sentinel.AUTH, model, method, *extra)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -130,7 +130,7 @@ class TestService(XmlRpcTestCase):
             if server_version <= 8.0:
                 expected_calls += [
                     call('login', ('newdb', 'usr', 'pss')),
-                    call('execute_kw', ('newdb', 1, 'pss', 'res.users', 'context_get'))
+                    call('execute_kw', ('newdb', 1, 'pss', 'res.users', 'context_get', ()))
                 ]
         else:
             # server_version, list, web_auth
@@ -185,7 +185,7 @@ class TestCreateClient(XmlRpcTestCase):
         client = odooly.Client(url_xmlrpc, 'newdb', 'usr', 'pss')
         expected_calls = self.startup_calls + (
             call.common.login('newdb', 'usr', 'pss'),
-            call.object.execute_kw('newdb', 1, 'pss', 'res.users', 'context_get'),
+            call.object.execute_kw('newdb', 1, 'pss', 'res.users', 'context_get', ()),
         )
         self.assertIsInstance(client, odooly.Client)
         self.assertCalls(*expected_calls)
@@ -216,7 +216,7 @@ class TestCreateClient(XmlRpcTestCase):
         self.service.common.login.return_value = 17
         getpass.reset_mock()
         expected_calls = expected_calls + (
-            call.object.execute_kw('database', 17, 'password', 'res.users', 'context_get'),
+            call.object.execute_kw('database', 17, 'password', 'res.users', 'context_get', ()),
         )
 
         client = odooly.Client(self.server, 'database', 'usr')
@@ -234,7 +234,7 @@ class TestCreateClient(XmlRpcTestCase):
         client = odooly.Client(url_xmlrpc, 'database', 'usr')
         self.assertIsInstance(client, odooly.Client)
         self.assertCalls(*(self.startup_calls + (
-            call.object.execute_kw('database', 1, 'password', 'res.users', 'context_get'),
+            call.object.execute_kw('database', 1, 'password', 'res.users', 'context_get', ()),
         )))
         self.assertOutput('')
 
@@ -260,7 +260,7 @@ class TestCreateClient(XmlRpcTestCase):
         read_config.reset_mock()
         getpass.reset_mock()
         expected_calls = expected_calls + (
-            call.object.execute_kw('database', 17, 'password', 'res.users', 'context_get'),
+            call.object.execute_kw('database', 17, 'password', 'res.users', 'context_get', ()),
         )
 
         client = odooly.Client.from_config('test')
@@ -369,11 +369,11 @@ class TestClientApi(XmlRpcTestCase):
         if float(self.server_version) <= 8.0:
             expected_calls[2:2] = [
                 call.common.login('db1', 'admin', 'admin'),
-                call.object.execute_kw('db1', 1, 'admin', 'res.users', 'context_get'),
+                call.object.execute_kw('db1', 1, 'admin', 'res.users', 'context_get', ()),
             ]
             expected_calls[6:] = [
                 call.common.login('db2', 'admin', 'secret'),
-                call.object.execute_kw('db2', 1, 'secret', 'res.users', 'context_get'),
+                call.object.execute_kw('db2', 1, 'secret', 'res.users', 'context_get', ()),
             ]
 
             self.assertRaises(
@@ -570,11 +570,9 @@ class TestClientApi(XmlRpcTestCase):
             OBJ('ir.model.access', 'check', 'res.users', 'write'),
             OBJ('res.users', 'search', [('login', '=', 'guest')]),
             OBJ('res.users', 'read', 123, ['id', 'login', 'password']),
-            ('object.execute_kw', self.database, 123, 'xxx',
-             'res.users', 'context_get'),
-
-            ('object.execute_kw', self.database, 1, 'passwd',
-             'res.users', 'context_get'),
+            ('object.execute_kw', self.database, 123, 'xxx', 'res.users', 'context_get', ()),
+            #
+            ('object.execute_kw', self.database, 1, 'passwd',  'res.users', 'context_get', ()),
             OBJ('ir.model.access', 'check', 'res.users', 'write', context=ctx_lang),
             ('object.execute_kw', self.database, 123, 'xxx',
              'ir.model.access', 'check', ('res.users', 'write'), {'context': ctx_lang}),

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -55,11 +55,11 @@ class TestInteract(XmlRpcTestCase):
         self.assertEqual(sys.ps2, '     ... ')
         expected_calls = self.startup_calls + (
             ('common.login', 'database', 'usr', 'password'),
-            ('object.execute_kw', 'database', 17, 'password', 'res.users', 'context_get'),
+            ('object.execute_kw', 'database', 17, 'password', 'res.users', 'context_get', ()),
             ('object.execute_kw', 'database', 17, 'password',
              'ir.model.access', 'check', ('res.users', 'write')),
             ('common.login', 'database', 'gaspard', 'password'),
-            ('object.execute_kw', 'database', 51, 'password', 'res.users', 'context_get'),
+            ('object.execute_kw', 'database', 51, 'password', 'res.users', 'context_get', ()),
         )
         self.assertCalls(*expected_calls)
         self.assertEqual(getpass.call_count, 2)
@@ -125,7 +125,7 @@ class TestInteract(XmlRpcTestCase):
 
         expected_calls = self.startup_calls + (
             ('common.login', 'database', 'usr', 'passwd'),
-            ('object.execute_kw', 'database', 17, 'passwd', 'res.users', 'context_get'),
+            ('object.execute_kw', 'database', 17, 'passwd', 'res.users', 'context_get', ()),
             usr17('ir.model', 'search',
                   [('model', 'like', 'res.company')]),
             usr17('ir.model', 'read', 42, ('model',)),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1327,7 +1327,7 @@ class TestRecord(TestCase):
                 kw['context'] = {'lang': 'en_US', 'tz': 'Europe/Zurich'}
             elif kw['context'] is None:
                 del kw['context']
-            extra = (params, kw) if kw else (params,) if params else ()
+            extra = (params, kw) if kw else (params,)
             return ('object.execute_kw', self.database, 1001, 'v_password',
                     model, method, *extra)
 


### PR DESCRIPTION
Change done in 2.3.0 breaks JSON-RPC / XML-RPC