### PR TITLE
Improve Webclient API usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 
 * Print HTTP error status when error occurs.
 
+* Support ``env._web.session('get_session_info')`` as alternative to
+  ``client.web_session.get_session_info()``, for example.
+
 
 2.3.1 (2025-09-30)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog
 ---------
 
 
+2.x.x (unreleased)
+~~~~~~~~~~~~~~~~~~
+
+* Print HTTP error status when error occurs.
+
+
 2.3.1 (2025-09-30)
 ~~~~~~~~~~~~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog
 * Support ``env._web.session('get_session_info')`` as alternative to
   ``client.web_session.get_session_info()``, for example.
 
+* When using Webclient, ``database =`` configuration becomes optional.
+
 
 2.3.1 (2025-09-30)
 ~~~~~~~~~~~~~~~~~~

--- a/odooly.ini
+++ b/odooly.ini
@@ -2,13 +2,15 @@
 scheme = http
 host = localhost
 port = 8069
-database = odoo
-username = admin
-options = -c /path/to/odoo-server.conf --without-demo all
 
 [demo]
 username = demo
 password = demo
 
+[admin]
+username = admin
+
 [local]
 scheme = local
+database = odoo
+options = -c /path/to/odoo-server.conf --without-demo all

--- a/odooly.py
+++ b/odooly.py
@@ -202,7 +202,9 @@ def format_exception(exc_type, exc, tb, limit=None, chain=True,
     values = _format_exception(exc_type, exc, tb, limit=limit)
     server_error = None
     if issubclass(exc_type, Error):             # Client-side
-        values = [str(exc) + '\n']
+        values = [f"{exc}\n"]
+    elif issubclass(exc_type, OSError):         # HTTPError (requests or urllib)
+        values = [f"{exc_type.__name__}: {exc}\n"]
     elif issubclass(exc_type, ServerError):     # JSON-RPC
         server_error = exc.args[0]['data']
     elif (issubclass(exc_type, Fault) and       # XML-RPC
@@ -1304,6 +1306,7 @@ class Client:
 
         def _post(self, url, *, method='POST', data=None, json=None, headers=None, **kw):
             resp = self._http_session.request(method, url, data=data, json=json, headers=headers, **kw)
+            resp.raise_for_status()
             return resp.text if json is None else resp.json()
 
     else:  # urllib.request

--- a/odooly.py
+++ b/odooly.py
@@ -415,15 +415,16 @@ class WebAPI:
                 return {**kw, **secret}.items()
             maxcol = MAXCOL[min(len(MAXCOL), self._verbose) - 1]
 
-            def wrapper(self, **params):
+            def wrapper(self, _func=None, **params):
+                method = f'{name}/{_func}' if _func else name
                 snt = ' '.join(f'{key}={v!r}' if v != ... else f'{key}=*'
                                for (key, v) in sanitize(params))
-                snt = f"POST {self._endpoint}/{name} {snt}"
+                snt = f"POST {self._endpoint}/{method} {snt}"
                 if len(snt) > maxcol:
                     suffix = f"... L={len(snt)}"
                     snt = snt[:maxcol - len(suffix)] + suffix
                 print(f"--> {snt}")
-                res = self._dispatch(name, params)
+                res = self._dispatch(method, params)
                 rcv = repr(res)
                 if len(rcv) > maxcol:
                     suffix = f"... L={len(rcv)}"
@@ -431,7 +432,8 @@ class WebAPI:
                 print(f"<-- {rcv}")
                 return res
         else:
-            wrapper = lambda s, **params: s._dispatch(name, params)
+            def wrapper(self, _func=None, **params):
+                return self._dispatch(f'{name}/{_func}' if _func else name, params)
         return _memoize(self, name, wrapper)
 
 


### PR DESCRIPTION

- Print HTTP error status when error occurs.

- Support ``env._web.session('get_session_info')`` as alternative to
  ``client.web_session.get_session_info()``, for example.

- When using Webclient, ``database =`` configuration becomes optional.

