### PR TITLE
[FIX] Fix authentication call by adding missing api_key parameter

### DIFF
--- a/odooly.py
+++ b/odooly.py
@@ -1455,7 +1455,7 @@ class Client:
         self.env._cache_set('auth', dict(auth_cache), db_name=database)
 
         # Login with the current user into the new database
-        (uid, password, __) = self.env._auth(self.env.uid, None, None)
+        (uid, password, __) = self.env._auth(self.env.uid, None, self.env._api_key)
         return self.login(self.env.user.login, password, database=database)
 
     def drop_database(self, passwd, database):


### PR DESCRIPTION
A new argument has been added to the_auth method as it is now required. This change ensures the method receives all necessary data for proper execution.