### PR TITLE
Add non-interactive mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@ Changelog
 ---------
 
 
+Unreleased
+~~~~~~~~~~
+
+* Add non-interactive mode.  Use ``--command "<code>"`` to run a Python
+  snippet against a connected client and exit, or pipe a script through
+  stdin (e.g. ``odooly --env demo < script.py``).  In both cases the
+  ``client`` and ``env`` globals are pre-populated and no REPL is started.
+
+
 2.6.5 (2026-04-12)
 ~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -125,3 +125,27 @@ This is a sample session::
    create an empty file in your home directory::
 
        ~$ touch ~/.odooly_history
+
+
+Non-interactive use
+-------------------
+
+Odooly can also run a snippet of Python against a connected client and
+exit, instead of dropping into the REPL.  This is convenient for scripts
+and one-off automations.
+
+Pass the code inline with ``--command``::
+
+    ~$ odooly --env demo --command 'print(env["res.users"].search_count([]))'
+
+Or pipe a script through stdin::
+
+    ~$ odooly --env demo < provision.py
+    ~$ cat <<'EOF' | odooly --env demo
+    ... users = env['res.users'].search([])
+    ... print(len(users), 'users')
+    ... EOF
+
+In both cases the ``client`` and ``env`` globals are pre-populated; no
+prompt is shown.  When stdin is not a terminal (e.g. inside CI), Odooly
+automatically reads the script from stdin.

--- a/odooly.py
+++ b/odooly.py
@@ -2459,8 +2459,33 @@ def get_parser():
     parser.add_argument(
         '-v', '--verbose', default=0, action='count',
         help='verbose')
+    parser.add_argument(
+        '--command', default=None, metavar='CMD',
+        help='program passed in as string; runs non-interactively')
     parser.add_argument('--version', action='version', version=__version__)
     return parser
+
+
+def _is_non_interactive(args):
+    return args.command is not None or not sys.stdin.isatty()
+
+
+def _exec_script(args):
+    """Run a script string or stdin against a connected client, then exit."""
+    client = connect_client(args)
+    if args.command is not None:
+        src, filename = args.command, '<string>'
+    else:
+        src, filename = sys.stdin.read(), '<stdin>'
+    ns = {
+        '__name__': '__main__',
+        '__doc__': None,
+        'Client': Client,
+        'client': client,
+        'env': client.env,
+    }
+    exec(compile(src, filename, 'exec'), ns)
+    return ns
 
 
 def connect_client(args):
@@ -2485,6 +2510,9 @@ def main(interact=_interact):
     if args.list_env:
         print('Available settings:  ' + ' '.join(read_config()))
         return
+
+    if _is_non_interactive(args):
+        return _exec_script(args)
 
     global_vars = Client._set_interactive()
     print(color_repr(USAGE))

--- a/odooly_run.py
+++ b/odooly_run.py
@@ -168,6 +168,10 @@ def main():
         print('Available settings:  ' + ' '.join(odooly.read_config()))
         return
 
+    if odooly._is_non_interactive(args):
+        odooly._exec_script(args)
+        return
+
     global_vars = odooly.Client._set_interactive()
     if odooly.color_py is not str or (os.getenv('FORCE_COLOR') and not os.getenv('NO_COLOR')):
         global_vars.update(patch_colors(odooly))

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -17,6 +17,8 @@ class _TestInteract(OdooTestCase):
         mock.patch.dict('sys.modules', {'readline': None}).start()
         # Hide _pyrepl module
         mock.patch.dict('sys.modules', {'_pyrepl': None}).start()
+        # Force interactive flow (test stdin is not a real tty)
+        mock.patch('sys.stdin.isatty', return_value=True).start()
         mock.patch('odooly.Client._globals', None).start()
         mock.patch('odooly.Client._set_interactive', wraps=odooly.Client._set_interactive).start()
         self.interact = mock.patch('odooly._interact', wraps=odooly._interact).start()
@@ -122,6 +124,40 @@ class TestInteractJsonRpc(JsonRpcTestCase, _TestInteract):
             "Error: Invalid username or password",
         ])
         self.assertOutput(stderr=ANY)
+
+    def test_command(self):
+        """--command runs a script then exits without invoking REPL."""
+        env_tuple = (self.server, 'database', 'usr', 'password', None)
+        mock.patch('sys.argv', new=['odooly', '--env', 'demo',
+                                    '--command', 'print(env.uid)\nprint(2 + 2)']).start()
+        mock.patch('odooly.Client.get_config', return_value=env_tuple).start()
+        self.service.database.list.return_value = ['database']
+        self.service.common.login.return_value = 17
+        self.service.object.execute_kw.return_value = {}
+
+        ns = odooly.main()
+
+        self.assertEqual(self.interact.call_count, 0)
+        self.assertEqual(ns['client'].env.uid, 17)
+        outlines = self.stdout.popvalue().splitlines()
+        self.assertSequenceEqual(outlines[-2:], ['17', '4'])
+
+    def test_stdin_pipe(self):
+        """Piped (non-tty) stdin runs as a script then exits without REPL."""
+        env_tuple = (self.server, 'database', 'usr', 'password', None)
+        mock.patch('sys.argv', new=['odooly', '--env', 'demo']).start()
+        mock.patch('sys.stdin.isatty', return_value=False).start()
+        mock.patch('sys.stdin.read', return_value='print(env.uid + 1)\n').start()
+        mock.patch('odooly.Client.get_config', return_value=env_tuple).start()
+        self.service.database.list.return_value = ['database']
+        self.service.common.login.return_value = 17
+        self.service.object.execute_kw.return_value = {}
+
+        odooly.main()
+
+        self.assertEqual(self.interact.call_count, 0)
+        outlines = self.stdout.popvalue().splitlines()
+        self.assertEqual(outlines[-1], '18')
 
     def test_invalid_user_password(self):
         env_tuple = (self.server, 'database', 'usr', 'passwd', None)


### PR DESCRIPTION
## Summary

Add a non-interactive mode so Odooly can be used in scripts and one-off automations without dropping into the REPL.

- ``--command "<code>"`` runs an inline Python snippet against a connected client, then exits.
- When stdin is not a TTY (piped script, heredoc, CI), stdin is read as a script and executed, then exits.

In both cases ``client`` and ``env`` are pre-populated as globals. ``Client._set_interactive()`` is **not** called, so the snippet behaves like a regular Python script: login errors propagate as exceptions, and REPL-only helpers like ``client.connect()`` raise.

## Note on the flag name

The de-facto standard short flag for "run inline code" is ``-c`` (``python -c``, ``bash -c``, ``sh -c``, ``perl -e``/``-c``, etc.). In Odooly ``-c`` is already taken by ``--config``, so this PR uses ``--command`` (long form only).

If you would like to free up ``-c`` for the convention, we could rename the short flag for ``--config`` in a follow-up. Options:

- ``-C, --config FILE`` (uppercase ``-C``, used by ``git -C`` and ``make -C`` for related concepts). Closest to the existing UX.
- Drop the short flag entirely and keep ``--config`` as long form only. Cleanest, very small breaking change for users who relied on ``-c``.
- ``-f, --config FILE``. Generic, less idiomatic.

This would be a breaking CLI change, so happy to keep ``--command`` as-is if you prefer to leave ``-c`` alone. Let me know which direction you want and I will fold it into this PR or open a separate one.

## Examples

```sh
odooly --env demo --command 'print(env["res.users"].search_count([]))'
odooly --env demo < provision.py
cat <<'PY' | odooly --env demo
users = env['res.users'].search([])
print(len(users), 'users')
PY
```

## Notes

- ``exec`` semantics, not REPL semantics: bare expressions do not auto-print, use ``print(...)``. This matches ``python -c "..."``.
- Existing interactive tests pin ``sys.stdin.isatty`` to ``True`` since pytest stdin is not a real TTY; otherwise auto-detection would route them to the script path.

## Test plan

- [x] ``python -m unittest tests.test_interact tests.test_client tests.test_model tests.test_util``: 286 tests pass (284 existing plus 2 new).
- [x] New ``test_command`` covers ``--command`` (no REPL invoked, snippet runs, ``env``/``client`` available).
- [x] New ``test_stdin_pipe`` covers non-tty stdin (no REPL invoked, stdin read and executed).
- [ ] Manual smoke test against a live Odoo instance.